### PR TITLE
feat: added key generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output

--- a/AppAttest/Sources/AppAttest/AppAttestProvider.swift
+++ b/AppAttest/Sources/AppAttest/AppAttestProvider.swift
@@ -1,3 +1,3 @@
 public protocol AppAttestProvider {
-
+    func fetchAttestation() async throws
 }

--- a/AppAttest/Sources/AppAttest/AppAttestService.swift
+++ b/AppAttest/Sources/AppAttest/AppAttestService.swift
@@ -17,9 +17,10 @@ public final class AppAttestService: AppAttestProvider {
         self.init(attestationProvider: DCAppAttestService.shared)
     }
 
-    func fetchAttestation() throws {
+    public func fetchAttestation() async throws {
         guard attestationProvider.isSupported else {
             throw AppAttestServiceError.unsupportedDevice
         }
+        _ = try await attestationProvider.generateKey()
     }
 }

--- a/AppAttest/Sources/AppAttest/AttestationProvider.swift
+++ b/AppAttest/Sources/AppAttest/AttestationProvider.swift
@@ -2,6 +2,7 @@ import DeviceCheck
 
 protocol AttestationProvider {
     var isSupported: Bool { get }
+
     func generateKey() async throws -> String
 }
 

--- a/AppAttest/Sources/AppAttest/AttestationProvider.swift
+++ b/AppAttest/Sources/AppAttest/AttestationProvider.swift
@@ -2,8 +2,7 @@ import DeviceCheck
 
 protocol AttestationProvider {
     var isSupported: Bool { get }
+    func generateKey() async throws -> String
 }
 
-extension DCAppAttestService: AttestationProvider {
-
-}
+extension DCAppAttestService: AttestationProvider { }

--- a/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
+++ b/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
@@ -1,4 +1,5 @@
 @testable import AppAttest
+import DeviceCheck
 import Testing
 
 struct AppAttestServiceTests {
@@ -25,8 +26,17 @@ struct AppAttestServiceTests {
     func supportedDeviceGeneratesKey() async throws {
         attestationProvider.isSupported = true
 
-        try await  sut.fetchAttestation()
+        try await sut.fetchAttestation()
         #expect(attestationProvider.didGenerateKey)
     }
 
+    @Test("Fetch attestation throws error from generate key")
+    func generatesKeyThrowsError() async throws {
+        let error = DCError(.featureUnsupported)
+        attestationProvider.generateKeyError = error
+
+        await #expect(throws: error) {
+            try await sut.fetchAttestation()
+        }
+    }
 }

--- a/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
+++ b/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
@@ -13,11 +13,20 @@ struct AppAttestServiceTests {
     }
 
     @Test("Throws error if device is unsupported")
-    func unsupportedDevice() {
+    func unsupportedDevice() async {
         attestationProvider.isSupported = false
 
-        #expect(throws: AppAttestServiceError.unsupportedDevice) {
-            try sut.fetchAttestation()
+        await #expect(throws: AppAttestServiceError.unsupportedDevice) {
+            try await sut.fetchAttestation()
         }
     }
+
+    @Test("Generates key if device is supported")
+    func supportedDeviceGeneratesKey() async throws {
+        attestationProvider.isSupported = true
+
+        try await  sut.fetchAttestation()
+        #expect(attestationProvider.didGenerateKey)
+    }
+
 }

--- a/AppAttest/Tests/AppAttestTests/Mocks/MockAttestationProvider.swift
+++ b/AppAttest/Tests/AppAttestTests/Mocks/MockAttestationProvider.swift
@@ -6,9 +6,15 @@ final class MockAttestationProvider: AttestationProvider {
     private(set) var didGenerateKey: Bool = false
 
     var isSupported: Bool = true
+    var generateKeyError: Error?
 
     func generateKey() async throws -> String {
         didGenerateKey = true
+
+        if let generateKeyError {
+            throw generateKeyError
+        }
+
         return key
     }
 }

--- a/AppAttest/Tests/AppAttestTests/Mocks/MockAttestationProvider.swift
+++ b/AppAttest/Tests/AppAttestTests/Mocks/MockAttestationProvider.swift
@@ -1,5 +1,14 @@
 @testable import AppAttest
+import Foundation
 
 final class MockAttestationProvider: AttestationProvider {
+    let key = UUID().uuidString
+    private(set) var didGenerateKey: Bool = false
+
     var isSupported: Bool = true
+
+    func generateKey() async throws -> String {
+        didGenerateKey = true
+        return key
+    }
 }

--- a/AppAttestDemo/AppAttestDemoApp.swift
+++ b/AppAttestDemo/AppAttestDemoApp.swift
@@ -3,13 +3,18 @@ import SwiftUI
 
 @main
 struct AppAttestDemoApp: App {
-    let service: AppAttestProvider = AppAttestService()
+    let appAttestProvider: AppAttestProvider = AppAttestService()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .task {
-                    // app attest!
+                    do {
+                        try await appAttestProvider
+                            .fetchAttestation()
+                    } catch {
+                        print("error: \(error.localizedDescription)")
+                    }
                 }
         }
     }


### PR DESCRIPTION
Creates a new cryptographic key for use with the App Attest service:
https://developer.apple.com/documentation/devicecheck/dcappattestservice/generatekey(completionhandler:)