### PR TITLE
feat: add support for fetching challenge from a remote server

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+line_length:
+  ignores_urls: true

--- a/AppAttest/Sources/AppAttest/AppAttestService.swift
+++ b/AppAttest/Sources/AppAttest/AppAttestService.swift
@@ -6,15 +6,21 @@ enum AppAttestServiceError: Error {
 
 public final class AppAttestService: AppAttestProvider {
     let attestationProvider: AttestationProvider
+    let challengeProvider: ChallengeProvider
 
     init(
-        attestationProvider: AttestationProvider
+        attestationProvider: AttestationProvider,
+        challengeProvider: ChallengeProvider
     ) {
         self.attestationProvider = attestationProvider
+        self.challengeProvider = challengeProvider
     }
 
-    public convenience init() {
-        self.init(attestationProvider: DCAppAttestService.shared)
+    public convenience init(challengeProvider: ChallengeProvider) {
+        self.init(
+            attestationProvider: DCAppAttestService.shared,
+            challengeProvider: challengeProvider
+        )
     }
 
     public func fetchAttestation() async throws {
@@ -22,5 +28,6 @@ public final class AppAttestService: AppAttestProvider {
             throw AppAttestServiceError.unsupportedDevice
         }
         _ = try await attestationProvider.generateKey()
+        _ = try await challengeProvider.challenge
     }
 }

--- a/AppAttest/Sources/AppAttest/ChallengeProvider.swift
+++ b/AppAttest/Sources/AppAttest/ChallengeProvider.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol ChallengeProvider {
+    var challenge: Data { get async throws }
+}

--- a/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
+++ b/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
@@ -3,13 +3,14 @@ import DeviceCheck
 import Testing
 
 struct AppAttestServiceTests {
-    let attestationProvider: MockAttestationProvider
+    let attestationProvider = MockAttestationProvider()
+    let challengeProvider = MockChallengeProvider()
     let sut: AppAttestService
 
     init() {
-        attestationProvider = MockAttestationProvider()
         sut = AppAttestService(
-            attestationProvider: attestationProvider
+            attestationProvider: attestationProvider,
+            challengeProvider: challengeProvider
         )
     }
 
@@ -38,5 +39,12 @@ struct AppAttestServiceTests {
         await #expect(throws: error) {
             try await sut.fetchAttestation()
         }
+    }
+
+    @Test("Fetch attestation requests challenge")
+    func fetchAttestationRequestsChallenge() async throws {
+        try await sut.fetchAttestation()
+
+        #expect(challengeProvider.didRequestChallenge)
     }
 }

--- a/AppAttest/Tests/AppAttestTests/Mocks/MockChallengeProvider.swift
+++ b/AppAttest/Tests/AppAttestTests/Mocks/MockChallengeProvider.swift
@@ -1,0 +1,14 @@
+import AppAttest
+import Foundation
+import Testing
+
+final class MockChallengeProvider: ChallengeProvider {
+    private(set) var didRequestChallenge = false
+
+    var challenge: Data {
+        get throws {
+            didRequestChallenge = true
+            return try #require("abc123".data(using: .utf8))
+        }
+    }
+}

--- a/AppAttest/Tests/AppAttestTests/Mocks/MockChallengeProvider.swift
+++ b/AppAttest/Tests/AppAttestTests/Mocks/MockChallengeProvider.swift
@@ -8,7 +8,7 @@ final class MockChallengeProvider: ChallengeProvider {
     var challenge: Data {
         get throws {
             didRequestChallenge = true
-            return try #require("abc123".data(using: .utf8))
+            return Data("abc123".utf8)
         }
     }
 }

--- a/AppAttestDemo/AppAttestDemoApp.swift
+++ b/AppAttestDemo/AppAttestDemoApp.swift
@@ -3,7 +3,9 @@ import SwiftUI
 
 @main
 struct AppAttestDemoApp: App {
-    let appAttestProvider: AppAttestProvider = AppAttestService()
+    let appAttestProvider: AppAttestProvider = AppAttestService(
+        challengeProvider: LocalChallengeProvider()
+    )
 
     var body: some Scene {
         WindowGroup {

--- a/AppAttestDemo/LocalChallengeProvider.swift
+++ b/AppAttestDemo/LocalChallengeProvider.swift
@@ -1,0 +1,19 @@
+import AppAttest
+import CryptoKit
+import Foundation
+
+/// This type implements the ChallengeProvider protocol for demo purposes
+/// In real world scenarios challenges should be provided and validated by your server
+///
+/// This implementation uses  a SHA256 hash of a unique, single-use 4-byte data block
+/// Apple recommends that a 16-byte block should be used in real environments:
+/// https://developer.apple.com/documentation/devicecheck/dcappattestservice/attestkey(_:clientdatahash:completionhandler:)
+struct LocalChallengeProvider: ChallengeProvider {
+    var challenge: Data {
+        let uuid = UUID()
+        let data = withUnsafePointer(to: uuid) {
+            Data(bytes: $0, count: MemoryLayout.size(ofValue: uuid))
+        }
+        return Data(SHA256.hash(data: data))
+    }
+}


### PR DESCRIPTION
The new `ChallengeProvider` protocol enables the `AppAttest` package to request a challenge from your server. The challenge should be a SHA256 hash of a unique, single-use data block of a challenge that is at least 16 bytes in length.

```swift
public protocol ChallengeProvider {
    var challenge: Data { get async throws }
}
```

See documentation for more details:
https://developer.apple.com/documentation/devicecheck/dcappattestservice/attestkey(_:clientdatahash:completionhandler:)