### PR TITLE
feat: decoded additional parameters in AttestationObject

### DIFF
--- a/AppAttest/Sources/AttestationDecoder/AttestationObject.swift
+++ b/AppAttest/Sources/AttestationDecoder/AttestationObject.swift
@@ -2,8 +2,12 @@ import Foundation
 
 public struct AttestationObject: Decodable {
     public let format: String
+    public let authenticatorData: Data
+    public let statement: AttestationStatement
 
     enum CodingKeys: String, CodingKey {
         case format = "fmt"
+        case authenticatorData = "authData"
+        case statement = "attStmt"
     }
 }

--- a/AppAttest/Sources/AttestationDecoder/AttestationStatement.swift
+++ b/AppAttest/Sources/AttestationDecoder/AttestationStatement.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public struct AttestationStatement: Decodable {
+    /// A chain of certificates in x.509 format
+    let certificateChain: [Data]
+    let receipt: Data
+
+    enum CodingKeys: String, CodingKey {
+        case certificateChain = "x5c"
+        case receipt
+    }
+}


### PR DESCRIPTION
Added additional parameters to decoding for `AttestationObject`, including `authData` and `attStmt`.

This Attestation Object returns by Apple follows the [WebAuthentication API specification](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/attestationObject).