### PR TITLE
chore: setup validation target

### DIFF
--- a/AppAttest.xctestplan
+++ b/AppAttest.xctestplan
@@ -15,8 +15,15 @@
     {
       "target" : {
         "containerPath" : "container:AppAttest",
-        "identifier" : "AppAttestTests",
-        "name" : "AppAttestTests"
+        "identifier" : "AttestationValidatorTests",
+        "name" : "AttestationValidatorTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:AppAttestDemo.xcodeproj",
+        "identifier" : "A779B9522CC6EDFE008128F4",
+        "name" : "AppAttestDemoTests"
       }
     },
     {
@@ -28,9 +35,9 @@
     },
     {
       "target" : {
-        "containerPath" : "container:AppAttestDemo.xcodeproj",
-        "identifier" : "A779B9522CC6EDFE008128F4",
-        "name" : "AppAttestDemoTests"
+        "containerPath" : "container:AppAttest",
+        "identifier" : "AppAttestTests",
+        "name" : "AppAttestTests"
       }
     }
   ],

--- a/AppAttest.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AppAttest.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "00ea1f21ec53ad991874ceb4cfa98e621a46129f348d27ec3bb358dd977a9be2",
+  "originHash" : "6df1860305c11720dd06fe4c95b8a68fc14a64142846a838674cdd92bc31e345",
   "pins" : [
     {
       "identity" : "cborcoding",
@@ -17,6 +17,33 @@
       "state" : {
         "revision" : "14b1ab35ffdf62c999ef1016ec0f8e745a6feed5",
         "version" : "1.4.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "7faebca1ea4f9aaf0cda1cef7c43aecd2311ddf6",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates",
+      "state" : {
+        "revision" : "1fbb6ef21f1525ed5faf4c95207b9c11bea27e94",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "06dc63c6d8da54ee11ceb268cde1fa68161afc96",
+        "version" : "3.9.1"
       }
     }
   ],

--- a/AppAttest/.swiftpm/xcode/xcuserdata/oliver.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AppAttest/.swiftpm/xcode/xcuserdata/oliver.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>AppAttest.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<key>AppAttestTests.xcscheme_^#shared#^_</key>
 		<dict>
@@ -18,6 +18,11 @@
 		<dict>
 			<key>orderHint</key>
 			<integer>2</integer>
+		</dict>
+		<key>AttestationValidatorTests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/AppAttest/Package.swift
+++ b/AppAttest/Package.swift
@@ -15,7 +15,14 @@ let package = Package(
         .library(name: "AppAttest", targets: ["AppAttest"])
     ],
     dependencies: [
-        .package(url: "https://github.com/SomeRandomiOSDev/CBORCoding", exact: "1.4.0")
+        .package(
+            url: "https://github.com/SomeRandomiOSDev/CBORCoding",
+            exact: "1.4.0"
+        ),
+        .package(
+            url: "https://github.com/apple/swift-certificates",
+            exact: "1.6.1"
+        )
     ],
     targets: [
         .target(name: "AppAttest"),
@@ -26,12 +33,25 @@ let package = Package(
 
         .target(
             name: "AttestationDecoder",
-            dependencies: [.product(name: "CBORCoding", package: "CBORCoding")]
+            dependencies: [
+                .product(name: "CBORCoding", package: "CBORCoding")
+            ]
         ),
         .testTarget(
             name: "AttestationDecoderTests",
             dependencies: ["AttestationDecoder"],
             resources: [.process("Resources")]
+        ),
+
+        .target(
+            name: "AttestationValidator",
+            dependencies: [
+                .product(name: "X509", package: "swift-certificates")
+            ]
+        ),
+        .testTarget(
+            name: "AttestationValidatorTests",
+            dependencies: ["AttestationValidator"]
         )
     ]
 )

--- a/AppAttest/Sources/AttestationDecoder/AttestationStatement.swift
+++ b/AppAttest/Sources/AttestationDecoder/AttestationStatement.swift
@@ -29,14 +29,4 @@ public struct AttestationStatement: Decodable {
         case certificateChain = "x5c"
         case receipt
     }
-
-    /// Validate this AttestationStatement using the steps given in the Device Check documentation:
-    /// https://developer.apple.com/documentation/devicecheck/attestation-object-validation-guide#Walking-through-the-validation-steps
-    private func validate() {
-        // 1. Verify that the x5c array contains the intermediate and leaf certificates for App Attest
-        // a) Intermediate certificate
-
-        // b) Leaf certificate
-
-    }
 }

--- a/AppAttest/Sources/AttestationValidator/AttestationObject.swift
+++ b/AppAttest/Sources/AttestationValidator/AttestationObject.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol AttestationObject {
+    var format: String { get }
+    var authenticatorData: Data { get }
+    var statement: AttestationStatement { get }
+}

--- a/AppAttest/Sources/AttestationValidator/AttestationStatement.swift
+++ b/AppAttest/Sources/AttestationValidator/AttestationStatement.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol AttestationStatement {
+    var certificateChain: [SecCertificate] { get }
+    var receipt: Data { get }
+}

--- a/AppAttest/Sources/AttestationValidator/AttestationValidator.swift
+++ b/AppAttest/Sources/AttestationValidator/AttestationValidator.swift
@@ -1,0 +1,17 @@
+import Foundation
+import X509
+
+public struct AttestationValidator {
+    /// Validate this AttestationStatement using the steps given in the Device Check documentation:
+    /// https://developer.apple.com/documentation/devicecheck/attestation-object-validation-guide#Walking-through-the-validation-steps
+    public static func validate(attestation: AttestationObject) throws {
+        let certificates = try attestation.statement
+            .certificateChain
+            .map(Certificate.init)
+        // 1. Verify that the x5c array contains the intermediate and leaf certificates for App Attest
+        // a) Intermediate certificate
+
+        // b) Leaf certificate
+
+    }
+}

--- a/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorTests.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorTests.swift
@@ -1,0 +1,9 @@
+import AttestationValidator
+import Testing
+
+struct AttestationValidatorTests {
+    @Test("Validate a valid attestation - throws no errors")
+    func validate() async throws {
+        try AttestationValidator.validate(attestation: .valid)
+    }
+}

--- a/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAttestationObject.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAttestationObject.swift
@@ -1,0 +1,19 @@
+import AttestationValidator
+import Foundation
+
+struct MockAttestationObject: AttestationObject {
+    let format: String
+    let authenticatorData: Data
+    let statement: AttestationStatement
+}
+
+extension AttestationObject
+where Self == MockAttestationObject {
+    static var valid: AttestationObject {
+        MockAttestationObject(
+            format: "",
+            authenticatorData: Data(),
+            statement: .valid
+        )
+    }
+}

--- a/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAttestationStatement.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAttestationStatement.swift
@@ -1,0 +1,17 @@
+import AttestationValidator
+import Foundation
+
+struct MockAttestationStatement: AttestationStatement {
+    let certificateChain: [SecCertificate]
+    let receipt: Data
+}
+
+extension AttestationStatement
+where Self == MockAttestationStatement {
+    static var valid: AttestationStatement {
+        MockAttestationStatement(
+            certificateChain: [],
+            receipt: Data()
+        )
+    }
+}


### PR DESCRIPTION
# Setup Validator target

Setup new target in the `AppAttest` package that enables validation of the `AttestationObject`.