### PR TITLE
feat: validate app ID is correct

### DIFF
--- a/AppAttest/Sources/AttestationDecoder/AttestationObject.swift
+++ b/AppAttest/Sources/AttestationDecoder/AttestationObject.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct AttestationObject: Decodable {
     public let format: String
-    public let authenticatorData: Data
+    public let authenticatorData: AuthenticatorData
     public let statement: AttestationStatement
 
     enum CodingKeys: String, CodingKey {

--- a/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
+++ b/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
@@ -1,0 +1,29 @@
+import CryptoKit
+import Foundation
+
+/// AuthenticatorData object as defined in the WebAuthn specification
+/// https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/Authenticator_data
+///
+/// This is an ArrayBuffer, at least 37 bytes in length, with the following fields:
+/// Field Name | No. Bytes | Description
+/// `rpIDHash` | 32 | SHA-256 hash of the relying party that the credential is scoped to (full App ID including Team ID)
+/// `flags` | 1 |
+/// `signCount` | 4 |  A signature counter, if supported by the authenticator (set to 0 otherwise)
+///
+///
+public struct AuthenticatorData: RawRepresentable, Decodable {
+    public let rawValue: Data
+
+    public init(rawValue data: Data) {
+        rawValue = data
+    }
+
+    public init(from decoder: any Decoder) throws {
+        var container = try decoder.singleValueContainer()
+        self.rawValue = try container.decode(Data.self)
+    }
+
+    var relyingPartyIDHash: Data {
+        rawValue[0..<32]
+    }
+}

--- a/AppAttest/Sources/AttestationValidator/AttestationObject.swift
+++ b/AppAttest/Sources/AttestationValidator/AttestationObject.swift
@@ -2,6 +2,6 @@ import Foundation
 
 public protocol AttestationObject {
     var format: String { get }
-    var authenticatorData: Data { get }
+    var authenticatorData: AuthenticatorData { get }
     var statement: AttestationStatement { get }
 }

--- a/AppAttest/Sources/AttestationValidator/AuthenticatorData.swift
+++ b/AppAttest/Sources/AttestationValidator/AuthenticatorData.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol AuthenticatorData {
+    var rawValue: Data { get }
+    var relyingPartyIDHash: Data { get }
+}

--- a/AppAttest/Tests/AttestationDecoderTests/AuthenticatorDataTests.swift
+++ b/AppAttest/Tests/AttestationDecoderTests/AuthenticatorDataTests.swift
@@ -1,0 +1,27 @@
+@testable import AttestationDecoder
+import Foundation
+import Testing
+
+struct AuthenticatorDataTests {
+    var authenticatorData: Data {
+        get throws {
+            try #require(Data(base64Encoded: """
+            CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2xAAAAAAGFwcGF0dGVzdGRldmVsb3A
+            AIH1Cj/hcabcKPp9XXIa/WOX0V6E2eg8/GurzszVtNzdSpQECAyYgASFYIECvB8wEheNQFz
+            Zl1SCINwg7rYImcdOd7JXaIXypG14ZIlggqzfw6JMMwuDa1jV6px5GFRJF6DY2PzBKpkHwJ
+            j82/fM=
+            """.filter { !$0.isWhitespace }))
+        }
+    }
+
+    @Test("Authenticator Data correctly extracts the relying party hash")
+    func rpIDHash() throws {
+        let sut = try AuthenticatorData(
+            rawValue: authenticatorData
+        )
+        #expect(
+            sut.relyingPartyIDHash.base64EncodedString() ==
+            "CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2w="
+        )
+    }
+}

--- a/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorTests.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorTests.swift
@@ -14,7 +14,27 @@ struct AttestationValidatorTests {
         let date = try #require(
             Calendar.current.date(from: components)
         )
-        sut = AttestationValidator(validationDate: date)
+        sut = AttestationValidator(
+            appID: "Z86DH46P79.uk.co.oliverbinns.app-attest",
+            validationDate: date
+        )
+    }
+
+    @Test("Correctly calculates app ID hash")
+    func appIDHash() {
+        #expect(
+            sut.appIDHash.base64EncodedString() ==
+            "CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2w="
+        )
+
+        let appleExample = AttestationValidator(
+            appID: "0352187391.com.apple.example_app_attest"
+        ).appIDHash
+
+        #expect(
+            appleExample.base64EncodedString() ==
+            "FVhAM8lQuf6dUUziohGjJtcaprEBSrTG+i+9qdmqGKY="
+        )
     }
 
     @Test("Validate a valid attestation - throws no errors")
@@ -89,7 +109,7 @@ struct AttestationValidatorTests {
     }
 
     @Test("Correctly accepts a valid AttestationObject")
-    func matchingChallenge() async throws {
+    func validAttestationObject() async throws {
         let challenge = try #require(Data(base64Encoded: "QhTa7IcbW7LTtQyi"))
 
         try await sut.validate(

--- a/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorWrongAppTests.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorWrongAppTests.swift
@@ -1,0 +1,35 @@
+@testable import AttestationValidator
+import Foundation
+import Testing
+
+struct AttestationValidatorWrongAppTests {
+    let sut: AttestationValidator
+
+    init() throws {
+        let components = DateComponents(
+            year: 2024, month: 11, day: 10,
+            hour: 12, minute: 0
+        )
+
+        let date = try #require(
+            Calendar.current.date(from: components)
+        )
+        sut = AttestationValidator(
+            appID: "Z86DH46P79.uk.co.oliverbinns.conferences",
+            validationDate: date
+        )
+    }
+
+    @Test("Correctly rejects AuthenticatorData from a different app")
+    func mismatchingRelyingPartyID() async throws {
+        let challenge = try #require(Data(base64Encoded: "QhTa7IcbW7LTtQyi"))
+
+        await #expect(throws: AttestationValidationError.wrongRelyingParty) {
+            try await sut.validate(
+                attestation: .valid,
+                challenge: challenge,
+                keyID: "fUKP+Fxptwo+n1dchr9Y5fRXoTZ6Dz8a6vOzNW03N1I="
+            )
+        }
+    }
+}

--- a/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAttestationObject.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAttestationObject.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct MockAttestationObject: AttestationObject {
     let format: String
-    let authenticatorData: Data
+    let authenticatorData: AuthenticatorData
     let statement: AttestationStatement
 }
 
@@ -14,7 +14,7 @@ where Self == MockAttestationObject {
         get throws {
             try MockAttestationObject(
                 format: "apple-appattest",
-                authenticatorData: authenticatorData,
+                authenticatorData: .valid,
                 statement: .valid
             )
         }
@@ -24,20 +24,9 @@ where Self == MockAttestationObject {
         get throws {
             try MockAttestationObject(
                 format: "apple-appattest",
-                authenticatorData: Data(),
+                authenticatorData: .valid,
                 statement: .expired
             )
-        }
-    }
-
-    private static var authenticatorData: Data {
-        get throws {
-            try #require(Data(base64Encoded: """
-            CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2xAAAAAAGFwcGF0dGVzdGRldmVsb3A
-            AIH1Cj/hcabcKPp9XXIa/WOX0V6E2eg8/GurzszVtNzdSpQECAyYgASFYIECvB8wEheNQFz
-            Zl1SCINwg7rYImcdOd7JXaIXypG14ZIlggqzfw6JMMwuDa1jV6px5GFRJF6DY2PzBKpkHwJ
-            j82/fM=
-            """.filter { !$0.isWhitespace }))
         }
     }
 }

--- a/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAuthenticatorData.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAuthenticatorData.swift
@@ -1,0 +1,29 @@
+import AttestationValidator
+import Foundation
+import Testing
+
+struct MockAuthenticatorData: AuthenticatorData {
+    let rawValue: Data
+    var relyingPartyIDHash: Data {
+        rawValue.subdata(in: 0..<32)
+    }
+}
+
+extension AuthenticatorData
+where Self == MockAuthenticatorData {
+    static var valid: AuthenticatorData {
+        get throws {
+            let raw = try #require(Data(base64Encoded: """
+            CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2xAAAAAAGFwcGF0dGVzdGRldmVsb3A
+            AIH1Cj/hcabcKPp9XXIa/WOX0V6E2eg8/GurzszVtNzdSpQECAyYgASFYIECvB8wEheNQFz
+            Zl1SCINwg7rYImcdOd7JXaIXypG14ZIlggqzfw6JMMwuDa1jV6px5GFRJF6DY2PzBKpkHwJ
+            j82/fM=
+            """.filter { !$0.isWhitespace }))
+
+            return MockAuthenticatorData(
+                rawValue: raw
+            )
+
+        }
+    }
+}


### PR DESCRIPTION
Complete step 6 of the [Attestation Object Validation Guide](https://developer.apple.com/documentation/devicecheck/attestation-object-validation-guide#Walking-through-the-validation-steps).

This check validates that the hashed app ID in the Authenticator Data matches the app we're expecting it to come from.

See [authenticator data details](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data) in the Web Authentication specification for more information.