### PR TITLE
feat: add sign count validation

### DIFF
--- a/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
+++ b/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
@@ -7,7 +7,7 @@ import Foundation
 /// This is an ArrayBuffer, at least 37 bytes in length, with the following fields:
 /// Field Name | No. Bytes | Description
 /// `rpIDHash` | 32 | SHA-256 hash of the relying party that the credential is scoped to (full App ID including Team ID)
-/// `flags` | 1 |
+/// `flags` | 1 | a number of boolean flags, including for whether the user is present
 /// `signCount` | 4 |  A signature counter, if supported by the authenticator (set to 0 otherwise)
 ///
 ///
@@ -19,11 +19,17 @@ public struct AuthenticatorData: RawRepresentable, Decodable {
     }
 
     public init(from decoder: any Decoder) throws {
-        var container = try decoder.singleValueContainer()
+        let container = try decoder.singleValueContainer()
         self.rawValue = try container.decode(Data.self)
     }
 
     var relyingPartyIDHash: Data {
         rawValue[0..<32]
+    }
+
+    var counter: Int {
+        rawValue[33..<37].reduce(0) { value, byte in
+            value << 8 | Int(byte)
+        }
     }
 }

--- a/AppAttest/Sources/AttestationValidator/AttestationValidator.swift
+++ b/AppAttest/Sources/AttestationValidator/AttestationValidator.swift
@@ -7,6 +7,7 @@ public enum AttestationValidationError: Error {
     case failedChallenge
     case incorrectSigningKey
     case wrongRelyingParty
+    case reusedAttestationKey
 }
 
 public struct AttestationValidator {
@@ -89,6 +90,9 @@ public struct AttestationValidator {
         }
 
         // 7. Verify that the authenticator data’s counter field equals 0.
+        guard attestation.authenticatorData.counter == 0 else {
+            throw AttestationValidationError.reusedAttestationKey
+        }
 
         // 8 . Verify that the authenticator data’s aaguid field is either appattestdevelop
         //     if operating in the development environment or appattest

--- a/AppAttest/Sources/AttestationValidator/AuthenticatorData.swift
+++ b/AppAttest/Sources/AttestationValidator/AuthenticatorData.swift
@@ -3,4 +3,5 @@ import Foundation
 public protocol AuthenticatorData {
     var rawValue: Data { get }
     var relyingPartyIDHash: Data { get }
+    var counter: Int { get }
 }

--- a/AppAttest/Tests/AttestationDecoderTests/AuthenticatorDataTests.swift
+++ b/AppAttest/Tests/AttestationDecoderTests/AuthenticatorDataTests.swift
@@ -5,12 +5,12 @@ import Testing
 struct AuthenticatorDataTests {
     var authenticatorData: Data {
         get throws {
-            try #require(Data(base64Encoded: """
+            try Data(base64Encoded: """
             CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2xAAAAAAGFwcGF0dGVzdGRldmVsb3A
             AIH1Cj/hcabcKPp9XXIa/WOX0V6E2eg8/GurzszVtNzdSpQECAyYgASFYIECvB8wEheNQFz
             Zl1SCINwg7rYImcdOd7JXaIXypG14ZIlggqzfw6JMMwuDa1jV6px5GFRJF6DY2PzBKpkHwJ
             j82/fM=
-            """.filter { !$0.isWhitespace }))
+            """)
         }
     }
 
@@ -24,4 +24,25 @@ struct AuthenticatorDataTests {
             "CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2w="
         )
     }
+
+    @Test("Authenticator Data correctly extracts the sign count")
+    func signCount() throws {
+        let sut = try AuthenticatorData(
+            rawValue: authenticatorData
+        )
+        #expect(
+            sut.counter == 0
+        )
+
+        let largeCount = AuthenticatorData(rawValue:
+            try Data(base64Encoded: """
+            CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2xAAAABEGFwcGF0dGVzdGRldmVsb3A
+            AIH1Cj/hcabcKPp9XXIa/WOX0V6E2eg8/GurzszVtNzdSpQECAyYgASFYIECvB8wEheNQFz
+            Zl1SCINwg7rYImcdOd7JXaIXypG14ZIlggqzfw6JMMwuDa1jV6px5GFRJF6DY2PzBKpkHwJ
+            j82/fM=
+            """)
+        )
+        #expect(largeCount.counter == 272)
+    }
+
 }

--- a/AppAttest/Tests/AttestationDecoderTests/Data.swift
+++ b/AppAttest/Tests/AttestationDecoderTests/Data.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Testing
+
+extension Data {
+    init(base64Encoded string: String) throws {
+        self = try #require(
+            Data(base64Encoded: string.filter { !$0.isWhitespace })
+        )
+    }
+}

--- a/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorTests.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/AttestationValidatorTests.swift
@@ -144,4 +144,30 @@ struct AttestationValidatorTests {
             )
         }
     }
+
+    @Test("Validator rejects object where count is greater than zero")
+    func reusedAttestationKey() async throws {
+        let challenge = try #require(Data(
+            base64Encoded: "QhTa7IcbW7LTtQyi"
+        ))
+
+        let authenticatorData = try MockAuthenticatorData(
+            rawValue: .authenticator,
+            counter: 1
+        )
+        let attestation = try MockAttestationObject(
+            format: "apple-appattest",
+            authenticatorData: authenticatorData,
+            statement: .valid
+        )
+
+        await #expect(throws: AttestationValidationError.reusedAttestationKey) {
+            try await sut.validate(
+                attestation: attestation,
+                challenge: challenge,
+                keyID: "fUKP+Fxptwo+n1dchr9Y5fRXoTZ6Dz8a6vOzNW03N1I="
+            )
+        }
+    }
+
 }

--- a/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAuthenticatorData.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAuthenticatorData.swift
@@ -7,23 +7,30 @@ struct MockAuthenticatorData: AuthenticatorData {
     var relyingPartyIDHash: Data {
         rawValue.subdata(in: 0..<32)
     }
+    let counter: Int
 }
 
 extension AuthenticatorData
 where Self == MockAuthenticatorData {
     static var valid: AuthenticatorData {
         get throws {
-            let raw = try #require(Data(base64Encoded: """
+            try MockAuthenticatorData(
+                rawValue: .authenticator,
+                counter: 0
+            )
+        }
+    }
+}
+
+extension Data {
+    static var authenticator: Data {
+        get throws {
+            try #require(Data(base64Encoded: """
             CVqj6oy4szHiiDd8cYbSvfsW9hVM3M8PUt8FUQyaY2xAAAAAAGFwcGF0dGVzdGRldmVsb3A
             AIH1Cj/hcabcKPp9XXIa/WOX0V6E2eg8/GurzszVtNzdSpQECAyYgASFYIECvB8wEheNQFz
             Zl1SCINwg7rYImcdOd7JXaIXypG14ZIlggqzfw6JMMwuDa1jV6px5GFRJF6DY2PzBKpkHwJ
             j82/fM=
             """.filter { !$0.isWhitespace }))
-
-            return MockAuthenticatorData(
-                rawValue: raw
-            )
-
         }
     }
 }


### PR DESCRIPTION
Complete step 7 of the [Attestation Object Validation Guide](https://developer.apple.com/documentation/devicecheck/attestation-object-validation-guide#Walking-through-the-validation-steps).

This check validates that the sign count of the Attestation Object is 0, meaning the key has not been used before.