### PR TITLE
feat: validation of credential ID in the authenticator data

### DIFF
--- a/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
+++ b/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
@@ -23,17 +23,24 @@ public struct AuthenticatorData: RawRepresentable, Decodable {
         self.rawValue = try container.decode(Data.self)
     }
 
-    var relyingPartyIDHash: Data {
+    public var relyingPartyIDHash: Data {
         rawValue[0..<32]
     }
 
-    var counter: Int {
-        rawValue[33..<37].reduce(0) { value, byte in
-            value << 8 | Int(byte)
-        }
+    public var counter: Int {
+        Int(data: rawValue[33..<37])
     }
 
-    var environment: Environment? {
+    public var environment: Environment? {
         Environment(bytes: rawValue[37..<53])
+    }
+
+    var credentialIDLength: Int {
+        Int(data: rawValue[53..<55])
+    }
+
+    var credentialID: String {
+        let endIndex = rawValue.index(55, offsetBy: credentialIDLength)
+        return rawValue[55..<endIndex].base64EncodedString()
     }
 }

--- a/AppAttest/Sources/AttestationDecoder/Extensions/Data.swift
+++ b/AppAttest/Sources/AttestationDecoder/Extensions/Data.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Int {
+    init(data: Data) {
+        self = data.reduce(0) { value, byte in
+            value << 8 | Int(byte)
+        }
+    }
+}

--- a/AppAttest/Sources/AttestationValidator/AttestationValidator.swift
+++ b/AppAttest/Sources/AttestationValidator/AttestationValidator.swift
@@ -108,7 +108,9 @@ public struct AttestationValidator {
         }
 
         // 9. Verify that the authenticator data’s credentialId field is the same as the key identifier.
-
+        guard attestation.authenticatorData.credentialID == keyID else {
+            throw AttestationValidationError.incorrectSigningKey
+        }
     }
 
     func validateCertificateChain(_ certificateChain: [Certificate]) async throws {

--- a/AppAttest/Sources/AttestationValidator/AuthenticatorData.swift
+++ b/AppAttest/Sources/AttestationValidator/AuthenticatorData.swift
@@ -5,6 +5,7 @@ public protocol AuthenticatorData {
     var relyingPartyIDHash: Data { get }
     var counter: Int { get }
     var environment: Environment? { get }
+    var credentialID: String { get }
 }
 
 public enum Environment {

--- a/AppAttest/Tests/AttestationDecoderTests/AuthenticatorDataTests.swift
+++ b/AppAttest/Tests/AttestationDecoderTests/AuthenticatorDataTests.swift
@@ -43,4 +43,14 @@ struct AuthenticatorDataTests {
         )
         #expect(unknown.environment == nil)
     }
+
+    @Test("Authenticator Data correctly extracts the key ID")
+    func keyID() throws {
+        let data = try Data(filename: "authenticator-data-valid")
+        let sut = AuthenticatorData(rawValue: data)
+        #expect(
+            sut.credentialID ==
+            "fUKP+Fxptwo+n1dchr9Y5fRXoTZ6Dz8a6vOzNW03N1I="
+        )
+    }
 }

--- a/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAuthenticatorData.swift
+++ b/AppAttest/Tests/AttestationValidatorTests/Mocks/MockAuthenticatorData.swift
@@ -9,17 +9,24 @@ struct MockAuthenticatorData: AuthenticatorData {
     }
     let counter: Int
     let environment: Environment?
+    let credentialID: String
+
+    init(rawValue: Data? = nil,
+         counter: Int = 0,
+         environment: Environment? = .development,
+         credentialID: String = "fUKP+Fxptwo+n1dchr9Y5fRXoTZ6Dz8a6vOzNW03N1I=") throws {
+        self.rawValue = try rawValue ?? .authenticator
+        self.counter = counter
+        self.environment = environment
+        self.credentialID = credentialID
+    }
 }
 
 extension AuthenticatorData
 where Self == MockAuthenticatorData {
     static var valid: AuthenticatorData {
         get throws {
-            try MockAuthenticatorData(
-                rawValue: .authenticator,
-                counter: 0,
-                environment: .development
-            )
+            try MockAuthenticatorData()
         }
     }
 }


### PR DESCRIPTION
Complete step 9 of the [Attestation Object Validation Guide](https://developer.apple.com/documentation/devicecheck/attestation-object-validation-guide#Walking-through-the-validation-steps).

This check validates that the credential ID in the Attestation Object is matches the expected value sent from the client app.