### PR TITLE
feat: client requests challenge from server

### DIFF
--- a/AppAttest/.swiftpm/xcode/xcuserdata/oliver.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AppAttest/.swiftpm/xcode/xcuserdata/oliver.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -17,7 +17,7 @@
 		<key>AttestServer.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>3</integer>
 		</dict>
 		<key>AttestationDecoderTests.xcscheme_^#shared#^_</key>
 		<dict>

--- a/AppAttest/Sources/AppAttest/AppAttestService.swift
+++ b/AppAttest/Sources/AppAttest/AppAttestService.swift
@@ -29,7 +29,8 @@ public final class AppAttestService: AppAttestProvider {
             throw AppAttestServiceError.unsupportedDevice
         }
         let keyID = try await attestationProvider.generateKey()
-        let challenge = try await challengeProvider.challenge
+        let challenge = try await challengeProvider
+            .challenge(for: keyID)
         let clientDataHash = Data(SHA256.hash(data: challenge))
 
         return try await attestationProvider.attestKey(

--- a/AppAttest/Sources/AppAttest/ChallengeProvider.swift
+++ b/AppAttest/Sources/AppAttest/ChallengeProvider.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol ChallengeProvider {
-    var challenge: Data { get async throws }
+    func challenge(for keyID: String) async throws -> Data
 }

--- a/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
+++ b/AppAttest/Tests/AppAttestTests/AppAttestServiceTests.swift
@@ -55,8 +55,11 @@ struct AppAttestServiceTests {
 
         #expect(attestationProvider.didAttestKey)
 
-        let expectedChallenge = try Data(
-            SHA256.hash(data: challengeProvider.challenge)
+        let challengeData = try await challengeProvider
+            .challenge(for: String())
+
+        let expectedChallenge = Data(
+            SHA256.hash(data: challengeData)
         )
         #expect(attestationProvider.challengeUsedForAttest ==
                 expectedChallenge)

--- a/AppAttest/Tests/AppAttestTests/Mocks/MockChallengeProvider.swift
+++ b/AppAttest/Tests/AppAttestTests/Mocks/MockChallengeProvider.swift
@@ -5,10 +5,8 @@ import Testing
 final class MockChallengeProvider: ChallengeProvider {
     private(set) var didRequestChallenge = false
 
-    var challenge: Data {
-        get throws {
-            didRequestChallenge = true
-            return Data("abc123".utf8)
-        }
+    func challenge(for keyID: String) async throws -> Data {
+        didRequestChallenge = true
+        return Data("abc123".utf8)
     }
 }

--- a/AppAttestDemo/AppAttestDemoApp.swift
+++ b/AppAttestDemo/AppAttestDemoApp.swift
@@ -4,7 +4,8 @@ import SwiftUI
 @main
 struct AppAttestDemoApp: App {
     let appAttestProvider: AppAttestProvider = AppAttestService(
-        challengeProvider: LocalChallengeProvider()
+        // challengeProvider: LocalChallengeProvider()
+        challengeProvider: RemoteChallengeProvider()
     )
 
     var body: some Scene {

--- a/AppAttestDemo/LocalChallengeProvider.swift
+++ b/AppAttestDemo/LocalChallengeProvider.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Apple recommends that a 16-byte block should be used in real environments:
 /// https://developer.apple.com/documentation/devicecheck/dcappattestservice/attestkey(_:clientdatahash:completionhandler:)
 struct LocalChallengeProvider: ChallengeProvider {
-    var challenge: Data {
+    func challenge(for keyID: String) async throws -> Data {
         Data(AES.GCM.Nonce())
     }
 }

--- a/AppAttestDemo/RemoteChallengeProvider.swift
+++ b/AppAttestDemo/RemoteChallengeProvider.swift
@@ -1,0 +1,51 @@
+import AppAttest
+import Foundation
+
+struct RemoteChallengeProvider: ChallengeProvider {
+    struct ChallengeResponse: Decodable {
+        let challenge: Data
+    }
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func challenge(for keyID: String) async throws -> Data {
+        let (data, _) = try await session
+            .data(for: .challenge(for: keyID))
+
+        let response = try JSONDecoder()
+            .decode(ChallengeResponse.self, from: data)
+
+        return response.challenge
+    }
+}
+
+extension URLRequest {
+    struct ChallengeRequest: Encodable {
+        let keyID: String
+    }
+
+    static func challenge(for keyID: String) throws -> URLRequest {
+        var request = URLRequest(url: .challenge)
+        request.httpMethod = "POST"
+        request.setValue(
+            "application/json",
+            forHTTPHeaderField: "Content-Type"
+        )
+
+        let requestBody = ChallengeRequest(keyID: keyID)
+        request.httpBody = try JSONEncoder()
+            .encode(requestBody)
+
+        return request
+    }
+}
+
+extension URL {
+    static var challenge: URL {
+        URL(string: "http://localhost:8080/challenge")!
+    }
+}

--- a/AppAttestDemoTests/Helpers/MockURLProtocol.swift
+++ b/AppAttestDemoTests/Helpers/MockURLProtocol.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public final class MockURLProtocol: URLProtocol {
+    public private(set) static var requests: [URLRequest] = []
+    private static var responses: [ URL: (data: Data, response: URLResponse) ] = [:]
+
+    public static func queueResponse(
+        _ response: (data: Data, response: URLResponse),
+        to url: URL
+    ) {
+        responses[url] = response
+    }
+
+    public static func clear() {
+        requests = []
+        responses = [:]
+    }
+
+    public override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    public override static func canInit(with request: URLRequest) -> Bool {
+        requests.append(request)
+        return true
+    }
+
+    public override func startLoading() {
+        if let url = self.request.url,
+           let response = MockURLProtocol.responses[url] {
+            client?.urlProtocol(self, didReceive: response.response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: response.data)
+        } else {
+            fatalError("No response queued for request \(request)")
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    public override func stopLoading() {
+        // This method is unused in the mock currently
+    }
+}
+
+extension URLSessionConfiguration {
+    static var mock: URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return configuration
+    }
+}

--- a/AppAttestDemoTests/Helpers/URLRequest.swift
+++ b/AppAttestDemoTests/Helpers/URLRequest.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension URLRequest {
+    func bodyStreamAsJSON() -> Any? {
+        guard let bodyStream = self.httpBodyStream else {
+            return nil
+        }
+
+        bodyStream.open()
+
+        // Will read 16 chars per iteration.
+        // Can use bigger buffer if needed
+        let bufferSize: Int = 16
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(
+            capacity: bufferSize
+        )
+
+        var data = Data()
+
+        while bodyStream.hasBytesAvailable {
+            let readData = bodyStream.read(buffer, maxLength: bufferSize)
+            data.append(buffer, count: readData)
+        }
+
+        buffer.deallocate()
+
+        bodyStream.close()
+
+        do {
+            return try JSONSerialization.jsonObject(
+                with: data,
+                options: .allowFragments
+            )
+        } catch {
+            print(error.localizedDescription)
+            return nil
+        }
+    }
+}

--- a/AppAttestDemoTests/RemoteChallengeProviderTests.swift
+++ b/AppAttestDemoTests/RemoteChallengeProviderTests.swift
@@ -1,0 +1,66 @@
+@testable import AppAttestDemo
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct RemoteChallengeProviderTests {
+    private let sut = RemoteChallengeProvider(
+        session: URLSession(configuration: .mock)
+    )
+
+    @Test("Makes correctly formatted request to remote endpoint")
+    func makeRequest() async throws {
+        let url = try #require(URL(string: "http://localhost:8080/challenge"))
+        let keyID = UUID().uuidString
+        MockURLProtocol.queueResponse(
+            (data: Data(), response: URLResponse()),
+            to: url
+        )
+
+        _ = try? await sut.challenge(for: keyID)
+
+        #expect(MockURLProtocol.requests.count == 1)
+
+        let request = try #require(MockURLProtocol.requests.first)
+        #expect(request.url == url)
+        #expect(request.httpMethod == "POST")
+        #expect(request.allHTTPHeaderFields == [
+            "Content-Type": "application/json",
+            "Content-Length": "48"
+        ])
+
+        let body = try #require(
+            request.bodyStreamAsJSON() as? [String: String]
+        )
+        #expect(body == ["keyID": keyID])
+    }
+
+    @Test("Decodes response from remote endpoint")
+    func decodeResponse() async throws {
+        let url = try #require(URL(string: "http://localhost:8080/challenge"))
+
+        let expectedChallenge = Data(UUID().uuidString.utf8)
+        let response = Data("""
+        { "challenge" : "\(expectedChallenge.base64EncodedString())" }
+        """.utf8)
+
+        MockURLProtocol.queueResponse(
+            (data: response, response: .success(url: url)),
+            to: url
+        )
+
+        let challenge = try await sut.challenge(for: String())
+        #expect(expectedChallenge == challenge)
+    }
+}
+
+extension URLResponse {
+    static func success(url: URL) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}


### PR DESCRIPTION
The mobile app now makes a request to the Vapor server.
This is implemented as a `ChallengeProvider` protocol.

### Server Logs
<img width="572" alt="image" src="https://github.com/user-attachments/assets/dd17eb95-f48f-4a6b-bade-29c30a69807a">

### App Logs
<img width="804" alt="image" src="https://github.com/user-attachments/assets/5887f885-5978-4f65-9f84-f6bafb9422f0">
