### PR TITLE
fix: authenticator data is decoded correctly from an attestation object

### DIFF
--- a/AppAttest.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AppAttest.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "426e6bc1b765e760b005e87259705e5cf61026b457accda83efabcdce9879a4f",
+  "originHash" : "fbe9f9f5a7ca57fdf367f31e00b363e809c12ec34fc1d0a60e8d2f0186985ecc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "e048c8ee94967e8d8a1c2ec0e1156d6f7fa34d31",
         "version" : "1.20.0"
-      }
-    },
-    {
-      "identity" : "cborcoding",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SomeRandomiOSDev/CBORCoding",
-      "state" : {
-        "revision" : "6fbd643c64cf6ef7a98391820c372d05fa9ed9ab",
-        "version" : "1.4.0"
       }
     },
     {
@@ -62,15 +53,6 @@
       "state" : {
         "revision" : "6e3a5ff7f2cb733771a6bd71dd3a491cce79f24d",
         "version" : "4.8.0"
-      }
-    },
-    {
-      "identity" : "half",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SomeRandomiOSDev/Half",
-      "state" : {
-        "revision" : "14b1ab35ffdf62c999ef1016ec0f8e745a6feed5",
-        "version" : "1.4.2"
       }
     },
     {
@@ -260,6 +242,15 @@
       "state" : {
         "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
         "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swiftcbor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/valpackett/SwiftCBOR.git",
+      "state" : {
+        "revision" : "04ccff117f6549121d5721ec84fdf0162122b90e",
+        "version" : "0.5.0"
       }
     },
     {

--- a/AppAttest/.swiftpm/xcode/xcuserdata/oliver.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AppAttest/.swiftpm/xcode/xcuserdata/oliver.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,11 +9,6 @@
 			<key>orderHint</key>
 			<integer>2</integer>
 		</dict>
-		<key>AppAttestTests.xcscheme_^#shared#^_</key>
-		<dict>
-			<key>orderHint</key>
-			<integer>2</integer>
-		</dict>
 		<key>AttestServer.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
@@ -22,12 +17,30 @@
 		<key>AttestationDecoderTests.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
+			<integer>7</integer>
+		</dict>
+		<key>AttestationDecodingTests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>4</integer>
+		</dict>
+		<key>AttestationValidationTests.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
 			<integer>2</integer>
 		</dict>
 		<key>AttestationValidatorTests.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>6</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>AttestServer</key>
+		<dict>
+			<key>primary</key>
+			<true/>
 		</dict>
 	</dict>
 </dict>

--- a/AppAttest/Package.swift
+++ b/AppAttest/Package.swift
@@ -23,8 +23,8 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/SomeRandomiOSDev/CBORCoding",
-            exact: "1.4.0"
+            url: "https://github.com/valpackett/SwiftCBOR.git",
+            exact: "0.5.0"
         ),
         .package(
             url: "https://github.com/apple/swift-certificates",
@@ -41,7 +41,7 @@ let package = Package(
         .target(
             name: "AttestationDecoder",
             dependencies: [
-                .product(name: "CBORCoding", package: "CBORCoding")
+                .product(name: "SwiftCBOR", package: "SwiftCBOR")
             ]
         ),
         .testTarget(

--- a/AppAttest/Sources/AttestationDecoder/AttestationDecoder.swift
+++ b/AppAttest/Sources/AttestationDecoder/AttestationDecoder.swift
@@ -1,14 +1,14 @@
-import CBORCoding
+import SwiftCBOR
 import Foundation
 
 public struct AttestationDecoder {
-    let decoder: CBORDecoder
+    let decoder: CodableCBORDecoder
 
-    public init(decoder: CBORDecoder = CBORDecoder()) {
+    public init(decoder: CodableCBORDecoder = CodableCBORDecoder()) {
         self.decoder = decoder
     }
 
     public func decode(data: Data) throws -> AttestationObject {
-        try decoder.decode(from: data)
+        try decoder.decode(AttestationObject.self, from: data)
     }
 }

--- a/AppAttest/Sources/AttestationDecoder/AttestationObject.swift
+++ b/AppAttest/Sources/AttestationDecoder/AttestationObject.swift
@@ -1,9 +1,26 @@
 import Foundation
 
-public struct AttestationObject: Decodable {
+public struct AttestationObject {
     public let format: String
     public let authenticatorData: AuthenticatorData
     public let statement: AttestationStatement
+
+}
+
+extension AttestationObject: Decodable {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.format = try container
+            .decode(String.self, forKey: .format)
+
+        let authenticatorData = try container
+            .decode(Data.self, forKey: .authenticatorData)
+        self.authenticatorData = AuthenticatorData(rawValue: authenticatorData)
+
+        self.statement = try container
+            .decode(AttestationStatement.self, forKey: .statement)
+    }
 
     enum CodingKeys: String, CodingKey {
         case format = "fmt"

--- a/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
+++ b/AppAttest/Sources/AttestationDecoder/AuthenticatorData.swift
@@ -11,16 +11,11 @@ import Foundation
 /// `signCount` | 4 |  A signature counter, if supported by the authenticator (set to 0 otherwise)
 ///
 ///
-public struct AuthenticatorData: RawRepresentable, Decodable {
+public struct AuthenticatorData: RawRepresentable {
     public let rawValue: Data
 
     public init(rawValue data: Data) {
         rawValue = data
-    }
-
-    public init(from decoder: any Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.rawValue = try container.decode(Data.self)
     }
 
     public var relyingPartyIDHash: Data {

--- a/AppAttest/Tests/AttestationDecoderTests/AttestationObjectTests.swift
+++ b/AppAttest/Tests/AttestationDecoderTests/AttestationObjectTests.swift
@@ -1,16 +1,16 @@
 import AttestationDecoder
-import CBORCoding
+import SwiftCBOR
 import Foundation
 import Testing
 
 struct AttestationObjectTests {
-    let decoder = CBORDecoder()
+    let decoder = CodableCBORDecoder()
     let sut: AttestationObject
 
     init() throws {
         let data = try Data(filename: "attest-base64")
         sut = try decoder.decode(
-            AttestationObject.self .self,
+            AttestationObject.self,
             from: data
         )
     }
@@ -18,5 +18,9 @@ struct AttestationObjectTests {
     @Test("Decoding of Attestation Object from Data")
     func testDecodingFromData() throws {
         #expect(sut.format == "apple-appattest")
+
+        #expect(sut.statement.certificateChain.count == 2)
+        #expect(sut.authenticatorData.relyingPartyIDHash.base64EncodedString() ==
+                "FVhAM8lQuf6dUUziohGjJtcaprEBSrTG+i+9qdmqGKY=")
     }
 }


### PR DESCRIPTION
Fixed Authenticator Data decoding by removing decodable conformance and manually decoding in the parent AttestationObject type.

Also migrated from `CBORCoding` to SwiftCBOR` to match NSLondon talk slides.